### PR TITLE
rename _cffi_backend module to _cffi_ft_backend

### DIFF
--- a/demo/manual2.py
+++ b/demo/manual2.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
-import _cffi_backend
+import _cffi_ft_backend
 
-ffi = _cffi_backend.FFI(b"manual2",
+ffi = _cffi_ft_backend.FFI(b"manual2",
     _version = 0x2601,
     _types = b'\x00\x00\x01\x0D\x00\x00\x07\x01\x00\x00\x00\x0F\x00\x00\x00\x09\x00\x00\x00\x0B\x00\x00\x01\x03',
     _globals = (b'\xff\xff\xff\x0bAA',0,b'\xff\xff\xff\x0bBB',-1,b'\xff\xff\xff\x0bCC',2,b'\xff\xff\xff\x1fFOO',0x9999999999999999,b'\x00\x00\x00#close',0,b'\x00\x00\x05#stdout',0),

--- a/doc/source/cdef.rst
+++ b/doc/source/cdef.rst
@@ -122,12 +122,12 @@ In order of complexity:
         ffibuilder.compile(verbose=True)
 
 * Note that some bundler tools that try to find all modules used by a
-  project, like PyInstaller, will miss ``_cffi_backend`` in the
+  project, like PyInstaller, will miss ``_cffi_ft_backend`` in the
   out-of-line mode because your program contains no explicit ``import
-  cffi`` or ``import _cffi_backend``.  You need to add
-  ``_cffi_backend`` explicitly (as a "hidden import" in PyInstaller,
+  cffi`` or ``import _cffi_ft_backend``.  You need to add
+  ``_cffi_ft_backend`` explicitly (as a "hidden import" in PyInstaller,
   but it can also be done more generally by adding the line ``import
-  _cffi_backend`` in your main program).
+  _cffi_ft_backend`` in your main program).
 
 Note that CFFI actually contains two different ``FFI`` classes.  The
 page `Using the ffi/lib objects`_ describes the common functionality.
@@ -145,11 +145,11 @@ from the different ``ffi`` object that you get by later saying
 
 The reason for this split of functionality is that a regular program
 using CFFI out-of-line does not need to import the ``cffi`` pure
-Python package at all.  (Internally it still needs ``_cffi_backend``,
+Python package at all.  (Internally it still needs ``_cffi_ft_backend``,
 a C extension module that comes with CFFI; this is why CFFI is also
 listed in ``install_requires=..`` above.  In the future this might be
 split into a different PyPI package that only installs
-``_cffi_backend``.)
+``_cffi_ft_backend``.)
 
 Note that a few small differences do exist: notably, ``from _foo import
 ffi`` returns an object of a type written in C, which does not let you
@@ -1006,9 +1006,9 @@ is hard-coded as a built-in module in PyPy:
 
 .. code-block:: python
 
-    if '_cffi_backend' in sys.builtin_module_names:   # PyPy
-        import _cffi_backend
-        requires_cffi = "cffi==" + _cffi_backend.__version__
+    if '_cffi_ft_backend' in sys.builtin_module_names:   # PyPy
+        import _cffi_ft_backend
+        requires_cffi = "cffi==" + _cffi_ft_backend.__version__
     else:
         requires_cffi = "cffi>=1.0.0"
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -646,7 +646,7 @@ functions.)
 The generated piece of C code should be the same independently on the
 platform on which you run it (or the Python version), so in simple cases
 you can directly distribute the pre-generated C code and treat it as a
-regular C extension module (which depends on the ``_cffi_backend``
+regular C extension module (which depends on the ``_cffi_ft_backend``
 module, on CPython).  The special Setuptools lines in the `example
 above`__ are meant for the more complicated cases where we need to
 regenerate the C sources as well---e.g. because the Python script that

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ if __name__ == '__main__':
     # On PyPy, cffi is preinstalled and it is not possible, at least for now,
     # to install a different version.  We work around it by making the setup()
     # arguments mostly empty in this case.
-    cpython = ('_cffi_backend' not in sys.builtin_module_names)
+    cpython = ('_cffi_ft_backend' not in sys.builtin_module_names)
 
     setup(
         packages=['cffi'] if cpython else [],
@@ -186,7 +186,7 @@ if __name__ == '__main__':
 
         distclass=CFFIDistribution,
         ext_modules=[Extension(
-            name='_cffi_backend',
+            name='_cffi_ft_backend',
             include_dirs=include_dirs,
             sources=sources,
             libraries=libraries,

--- a/setup_base.py
+++ b/setup_base.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     standard = '__pypy__' not in sys.builtin_module_names
     setup(packages=['cffi'],
           requires=['pycparser'],
-          ext_modules=[Extension(name = '_cffi_backend',
+          ext_modules=[Extension(name = '_cffi_ft_backend',
                                  include_dirs=include_dirs,
                                  sources=sources,
                                  libraries=libraries,

--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -248,6 +248,9 @@ static int PyWeakref_GetRef(PyObject *ref, PyObject **pobj)
 # define UNLOCK_UNIQUE_CACHE() ((void)0)
 #endif
 
+#define CFFI_BACKEND_MODULE_NAME "_cffi_ft_backend"
+#define CFFI_BACKEND_MODULE_NAME_LENGTH 16
+
 /************************************************************/
 
 /* base type flag: exactly one of the following: */
@@ -782,7 +785,7 @@ static PyMethodDef ctypedescr_methods[] = {
 
 static PyTypeObject CTypeDescr_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.CType",
+    "_cffi_ft_backend.CType",
     offsetof(CTypeDescrObject, ct_name),
     sizeof(char),
     (destructor)ctypedescr_dealloc,             /* tp_dealloc */
@@ -824,7 +827,7 @@ get_field_name(CTypeDescrObject *ct, CFieldObject *cf)
         if (d_value == (PyObject *)cf)
             return d_key;
     }
-    Py_FatalError("_cffi_backend: get_field_name()");
+    Py_FatalError("_cffi_ft_backend: get_field_name()");
     return NULL;
 }
 
@@ -850,7 +853,7 @@ static PyMemberDef cfield_members[] = {
 
 static PyTypeObject CField_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.CField",
+    "_cffi_ft_backend.CField",
     sizeof(CFieldObject),
     0,
     (destructor)cfield_dealloc,                 /* tp_dealloc */
@@ -3530,7 +3533,7 @@ static PyMethodDef cdata_methods[] = {
 
 static PyTypeObject CData_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend._CDataBase",
+    "_cffi_ft_backend._CDataBase",
     sizeof(CDataObject),
     0,
     (destructor)cdata_dealloc,                  /* tp_dealloc */
@@ -3574,7 +3577,7 @@ static PyTypeObject CData_Type = {
 
 static PyTypeObject CDataOwning_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.__CDataOwn",
+    "_cffi_ft_backend.__CDataOwn",
     sizeof(CDataObject),
     0,
     (destructor)cdataowning_dealloc,            /* tp_dealloc */
@@ -3617,7 +3620,7 @@ static PyTypeObject CDataOwning_Type = {
 
 static PyTypeObject CDataOwningGC_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.__CDataOwnGC",
+    "_cffi_ft_backend.__CDataOwnGC",
     sizeof(CDataObject_own_structptr),
     0,
     (destructor)cdataowninggc_dealloc,          /* tp_dealloc */
@@ -3661,7 +3664,7 @@ static PyTypeObject CDataOwningGC_Type = {
 
 static PyTypeObject CDataFromBuf_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.__CDataFromBuf",
+    "_cffi_ft_backend.__CDataFromBuf",
     sizeof(CDataObject_frombuf),
     0,
     (destructor)cdatafrombuf_dealloc,           /* tp_dealloc */
@@ -3705,7 +3708,7 @@ static PyTypeObject CDataFromBuf_Type = {
 
 static PyTypeObject CDataGCP_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.__CDataGCP",
+    "_cffi_ft_backend.__CDataGCP",
     sizeof(CDataObject_gcp),
     0,
     (destructor)cdatagcp_dealloc,               /* tp_dealloc */
@@ -3790,7 +3793,7 @@ cdataiter_dealloc(CDataIterObject *it)
 
 static PyTypeObject CDataIter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.__CData_iterator",       /* tp_name */
+    "_cffi_ft_backend.__CData_iterator",       /* tp_name */
     sizeof(CDataIterObject),                /* tp_basicsize */
     0,                                      /* tp_itemsize */
     /* methods */
@@ -4565,7 +4568,7 @@ static PyMethodDef dl_methods[] = {
 
 static PyTypeObject dl_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.CLibrary",           /* tp_name */
+    "_cffi_ft_backend.CLibrary",           /* tp_name */
     sizeof(DynLibObject),               /* tp_basicsize */
     0,                                  /* tp_itemsize */
     /* methods */
@@ -8207,7 +8210,7 @@ static struct { const char *name; int value; } all_dlopen_flags[] = {
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef FFIBackendModuleDef = {
   PyModuleDef_HEAD_INIT,
-  "_cffi_backend",
+  CFFI_BACKEND_MODULE_NAME,
   NULL,
   -1,
   FFIBackendMethods,
@@ -8216,7 +8219,7 @@ static struct PyModuleDef FFIBackendModuleDef = {
 #define INITERROR return NULL
 
 PyMODINIT_FUNC
-PyInit__cffi_backend(void)
+PyInit__cffi_ft_backend(void)
 #else
 #define INITERROR return
 
@@ -8256,7 +8259,7 @@ init_cffi_backend(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&FFIBackendModuleDef);
 #else
-    m = Py_InitModule("_cffi_backend", FFIBackendMethods);
+    m = Py_InitModule(CFFI_BACKEND_MODULE_NAME, FFIBackendMethods);
 #endif
 
     if (m == NULL)
@@ -8276,7 +8279,8 @@ init_cffi_backend(void)
     for (i = 0; all_types[i] != NULL; i++) {
         PyTypeObject *tp = all_types[i];
         PyObject *tpo = (PyObject *)tp;
-        if (strncmp(tp->tp_name, "_cffi_backend.", 14) != 0) {
+        if (strncmp(tp->tp_name, CFFI_BACKEND_MODULE_NAME".",
+                    CFFI_BACKEND_MODULE_NAME_LENGTH + 1) != 0) {
             PyErr_Format(PyExc_ImportError,
                          "'%s' is an ill-formed type name", tp->tp_name);
             INITERROR;
@@ -8285,12 +8289,12 @@ init_cffi_backend(void)
             INITERROR;
 
         Py_INCREF(tpo);
-        if (PyModule_AddObject(m, tp->tp_name + 14, tpo) < 0)
+        if (PyModule_AddObject(m, tp->tp_name + CFFI_BACKEND_MODULE_NAME_LENGTH + 1, tpo) < 0)
             INITERROR;
     }
 
     if (!init_done) {
-        v = PyText_FromString("_cffi_backend");
+        v = PyText_FromString(CFFI_BACKEND_MODULE_NAME);
         if (v == NULL || PyDict_SetItemString(CData_Type.tp_dict,
                                               "__module__", v) < 0)
             INITERROR;

--- a/src/c/call_python.c
+++ b/src/c/call_python.c
@@ -47,7 +47,7 @@ static PyObject *_get_interpstate_dict(void)
     /* from there on, we know the (sub-)interpreter is still valid */
 
     if (attr_name == NULL) {
-        attr_name = PyText_InternFromString("__cffi_backend_extern_py");
+        attr_name = PyText_InternFromString("__cffi_ft_backend_extern_py");
         if (attr_name == NULL)
             goto error;
     }

--- a/src/c/cglob.c
+++ b/src/c/cglob.c
@@ -20,7 +20,7 @@ static void glob_support_dealloc(GlobSupportObject *gs)
 
 static PyTypeObject GlobSupport_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.__FFIGlobSupport",
+    "_cffi_ft_backend.__FFIGlobSupport",
     sizeof(GlobSupportObject),
     0,
     (destructor)glob_support_dealloc,           /* tp_dealloc */

--- a/src/c/ffi_obj.c
+++ b/src/c/ffi_obj.c
@@ -1164,7 +1164,7 @@ static PyGetSetDef ffi_getsets[] = {
 
 static PyTypeObject FFI_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.FFI",
+    "_cffi_ft_backend.FFI",
     sizeof(FFIObject),
     0,
     (destructor)ffi_dealloc,                    /* tp_dealloc */

--- a/src/c/lib_obj.c
+++ b/src/c/lib_obj.c
@@ -598,7 +598,7 @@ static PyMethodDef lib_methods[] = {
 
 static PyTypeObject Lib_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.Lib",
+    "_cffi_ft_backend.Lib",
     sizeof(LibObject),
     0,
     (destructor)lib_dealloc,                    /* tp_dealloc */

--- a/src/c/minibuffer.h
+++ b/src/c/minibuffer.h
@@ -344,7 +344,7 @@ b_buffer_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 
 static PyTypeObject MiniBuffer_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.buffer",
+    "_cffi_ft_backend.buffer",
     sizeof(MiniBufferObj),
     0,
     (destructor)mb_dealloc,                     /* tp_dealloc */

--- a/src/c/misc_thread_common.h
+++ b/src/c/misc_thread_common.h
@@ -237,7 +237,7 @@ thread_canary_register(PyThreadState *tstate)
 
 static PyTypeObject ThreadCanary_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_cffi_backend.thread_canary",
+    "_cffi_ft_backend.thread_canary",
     sizeof(ThreadCanaryObj),
     0,
     (destructor)thread_canary_dealloc,          /* tp_dealloc */

--- a/src/c/test_c.py
+++ b/src/c/test_c.py
@@ -21,14 +21,14 @@ def _setup_path():
     import os, sys
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 _setup_path()
-from _cffi_backend import *
-from _cffi_backend import _get_types, _get_common_types
+from _cffi_ft_backend import *
+from _cffi_ft_backend import _get_types, _get_common_types
 try:
-    from _cffi_backend import _testfunc
+    from _cffi_ft_backend import _testfunc
 except ImportError:
     def _testfunc(num):
         pytest.skip("_testunc() not available")
-from _cffi_backend import __version__
+from _cffi_ft_backend import __version__
 
 
 @contextlib.contextmanager
@@ -65,7 +65,7 @@ def _assert_unraisable(error_type: type[Exception] | None, message: str = '', tr
 import sys
 assert __version__ == "1.18.0.dev0", ("This test_c.py file is for testing a version"
                                  " of cffi that differs from the one that we"
-                                 " get from 'import _cffi_backend'")
+                                 " get from 'import _cffi_ft_backend'")
 if sys.version_info < (3,):
     type_or_class = "type"
     mandatory_b_prefix = ''
@@ -163,7 +163,7 @@ def test_cast_to_signed_char():
     p = new_primitive_type("signed char")
     x = cast(p, -65 + 17*256)
     assert repr(x) == "<cdata 'signed char' -65>"
-    assert repr(type(x)) == "<%s '_cffi_backend._CDataBase'>" % type_or_class
+    assert repr(type(x)) == "<%s '_cffi_ft_backend._CDataBase'>" % type_or_class
     assert int(x) == -65
     x = cast(p, -66 + (1<<199)*256)
     assert repr(x) == "<cdata 'signed char' -66>"
@@ -2457,7 +2457,7 @@ def test_buffer():
     c = newp(BCharArray, b"hi there")
     #
     buf = buffer(c)
-    assert repr(buf).startswith('<_cffi_backend.buffer object at 0x')
+    assert repr(buf).startswith('<_cffi_ft_backend.buffer object at 0x')
     assert bytes(buf) == b"hi there\x00"
     assert type(buf) is buffer
     if sys.version_info < (3,):
@@ -3250,7 +3250,7 @@ def test_setslice_array():
 def test_cdata_name_module_doc():
     p = new_primitive_type("signed char")
     x = cast(p, 17)
-    assert x.__module__ == '_cffi_backend'
+    assert x.__module__ == '_cffi_ft_backend'
     assert x.__name__ == '<cdata>'
     assert hasattr(x, '__doc__')
 
@@ -3805,7 +3805,7 @@ def test_from_buffer_bytearray():
 
 def test_from_buffer_more_cases():
     try:
-        from _cffi_backend import _testbuff
+        from _cffi_ft_backend import _testbuff
     except ImportError:
         pytest.skip("not for pypy")
     BChar = new_primitive_type("char")
@@ -4504,13 +4504,13 @@ def test_huge_structure():
     assert sizeof(BStruct) == sys.maxsize
 
 def test_get_types():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     CData, CType = _get_types()
     assert CData is _cffi_backend._CDataBase
     assert CType is _cffi_backend.CType
 
 def test_type_available_with_correct_names():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     check_names = [
         'CType',
         'CField',
@@ -4539,7 +4539,7 @@ def test_type_available_with_correct_names():
     for name in check_names:
         tp = getattr(_cffi_backend, name)
         assert isinstance(tp, type)
-        assert (tp.__module__, tp.__name__) == ('_cffi_backend', name)
+        assert (tp.__module__, tp.__name__) == ('_cffi_ft_backend', name)
 
 def test_unaligned_types():
     BByteArray = new_array_type(

--- a/src/cffi/_cffi_include.h
+++ b/src/cffi/_cffi_include.h
@@ -243,7 +243,7 @@ static PyObject *_cffi_init(const char *module_name, Py_ssize_t version,
         (void *)ctx,
     };
 
-    module = PyImport_ImportModule("_cffi_backend");
+    module = PyImport_ImportModule("_cffi_ft_backend");
     if (module == NULL)
         goto failure;
 

--- a/src/cffi/_embedding.h
+++ b/src/cffi/_embedding.h
@@ -140,7 +140,7 @@ static void _cffi_py_initialize(void)
 
 static int _cffi_initialize_python(void)
 {
-    /* This initializes Python, imports _cffi_backend, and then the
+    /* This initializes Python, imports _cffi_ft_backend, and then the
        present .dll/.so is set up as a CPython C extension module.
     */
     int result;
@@ -190,7 +190,7 @@ static int _cffi_initialize_python(void)
        only hope that the Python code did correctly set up the
        corresponding @ffi.def_extern() function.  Otherwise, the
        general logic of ``extern "Python"`` functions (inside the
-       _cffi_backend module) will find that the reference is still
+       _cffi_ft_backend module) will find that the reference is still
        missing and print an error.
      */
     result = 0;
@@ -226,9 +226,9 @@ static int _cffi_initialize_python(void)
         if (f != NULL && f != Py_None) {
             PyFile_WriteString("\nFrom: " _CFFI_MODULE_NAME
                                "\ncompiled with cffi version: 1.18.0.dev0"
-                               "\n_cffi_backend module: ", f);
+                               "\n_cffi_ft_backend module: ", f);
             modules = PyImport_GetModuleDict();
-            mod = PyDict_GetItemString(modules, "_cffi_backend");
+            mod = PyDict_GetItemString(modules, "_cffi_ft_backend");
             if (mod == NULL) {
                 PyFile_WriteString("not loaded", f);
             }
@@ -476,7 +476,7 @@ static _cffi_call_python_fnptr _cffi_start_python(void)
                '_cffi_call_python' without also seeing the rest of the
                data initialized.  However, this is not possible.  But
                the new value of '_cffi_call_python' is the function
-               'cffi_call_python()' from _cffi_backend.  So:  */
+               'cffi_call_python()' from _cffi_ft_backend.  So:  */
             cffi_write_barrier();
             /* ^^^ we put a write barrier here, and a corresponding
                read barrier at the start of cffi_call_python().  This

--- a/src/cffi/api.py
+++ b/src/cffi/api.py
@@ -44,19 +44,19 @@ class FFI(object):
         """
         if backend is None:
             # You need PyPy (>= 2.0 beta), or a CPython (>= 2.6) with
-            # _cffi_backend.so compiled.
-            import _cffi_backend as backend
+            # _cffi_ft_backend.so compiled.
+            import _cffi_ft_backend as backend
             from . import __version__
             if backend.__version__ != __version__:
                 # bad version!  Try to be as explicit as possible.
                 if hasattr(backend, '__file__'):
                     # CPython
-                    raise Exception("Version mismatch: this is the 'cffi' package version %s, located in %r.  When we import the top-level '_cffi_backend' extension module, we get version %s, located in %r.  The two versions should be equal; check your installation." % (
+                    raise Exception("Version mismatch: this is the 'cffi' package version %s, located in %r.  When we import the top-level '_cffi_ft_backend' extension module, we get version %s, located in %r.  The two versions should be equal; check your installation." % (
                         __version__, __file__,
                         backend.__version__, backend.__file__))
                 else:
                     # PyPy
-                    raise Exception("Version mismatch: this is the 'cffi' package version %s, located in %r.  This interpreter comes with a built-in '_cffi_backend' module, which is version %s.  The two versions should be equal; check your installation." % (
+                    raise Exception("Version mismatch: this is the 'cffi' package version %s, located in %r.  This interpreter comes with a built-in '_cffi_ft_backend' module, which is version %s.  The two versions should be equal; check your installation." % (
                         __version__, __file__, backend.__version__))
             # (If you insist you can also try to pass the option
             # 'backend=backend_ctypes.CTypesBackend()', but don't
@@ -88,7 +88,7 @@ class FFI(object):
             self.BVoidP = self._get_cached_btype(model.voidp_type)
             self.BCharA = self._get_cached_btype(model.char_array_type)
         if isinstance(backend, types.ModuleType):
-            # _cffi_backend: attach these constants to the class
+            # _cffi_ft_backend: attach these constants to the class
             if not hasattr(FFI, 'NULL'):
                 FFI.NULL = self.cast(self.BVoidP, 0)
                 FFI.CData, FFI.CType = backend._get_types()

--- a/src/cffi/backend_ctypes.py
+++ b/src/cffi/backend_ctypes.py
@@ -737,9 +737,9 @@ class CTypesBackend(object):
                                  totalsize=-1, totalalignment=-1, sflags=0,
                                  pack=0):
         if totalsize >= 0 or totalalignment >= 0:
-            raise NotImplementedError("the ctypes backend of CFFI does not support "
+            raise NotImplementedError("the ctypes backend of CFFI_ft does not support "
                                       "structures completed by verify(); please "
-                                      "compile and install the _cffi_backend module.")
+                                      "compile and install the _cffi_ft_backend module.")
         struct_or_union = CTypesStructOrUnion._ctype
         fnames = [fname for (fname, BField, bitsize) in fields]
         btypes = [BField for (fname, BField, bitsize) in fields]

--- a/src/cffi/commontypes.py
+++ b/src/cffi/commontypes.py
@@ -7,7 +7,7 @@ COMMON_TYPES = {}
 
 try:
     # fetch "bool" and all simple Windows types
-    from _cffi_backend import _get_common_types
+    from _cffi_ft_backend import _get_common_types
     _get_common_types(COMMON_TYPES)
 except ImportError:
     pass

--- a/src/cffi/model.py
+++ b/src/cffi/model.py
@@ -577,7 +577,7 @@ global_lock = allocate_lock()
 _typecache_cffi_backend = weakref.WeakValueDictionary()
 
 def get_typecache(backend):
-    # returns _typecache_cffi_backend if backend is the _cffi_backend
+    # returns _typecache_cffi_backend if backend is the _cffi_ft_backend
     # module, or type(backend).__typecache if backend is an instance of
     # CTypesBackend (or some FakeBackend class during tests)
     if isinstance(backend, types.ModuleType):

--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -481,7 +481,7 @@ class Recompiler:
         #
         # header
         prnt("# auto-generated file")
-        prnt("import _cffi_backend")
+        prnt("import _cffi_ft_backend as _cffi_backend")
         #
         # the 'import' of the included ffis
         num_includes = len(self.ffi._included_ffis or ())

--- a/src/cffi/vengine_cpy.py
+++ b/src/cffi/vengine_cpy.py
@@ -1054,7 +1054,7 @@ static int _cffi_init(void)
 {
     PyObject *module, *c_api_object = NULL;
 
-    module = PyImport_ImportModule("_cffi_backend");
+    module = PyImport_ImportModule("_cffi_ft_backend");
     if (module == NULL)
         goto failure;
 

--- a/src/cffi/verifier.py
+++ b/src/cffi/verifier.py
@@ -227,10 +227,10 @@ def _locate_engine_class(ffi, force_generic_engine):
             force_generic_engine = True
         else:
             try:
-                import _cffi_backend
+                import _cffi_ft_backend
             except ImportError:
-                _cffi_backend = '?'
-            if ffi._backend is not _cffi_backend:
+                _cffi_ft_backend = '?'
+            if ffi._backend is not _cffi_ft_backend:
                 force_generic_engine = True
     if force_generic_engine:
         from . import vengine_gen

--- a/testing/cffi0/test_ffi_backend.py
+++ b/testing/cffi0/test_ffi_backend.py
@@ -3,7 +3,7 @@ import pytest
 from testing.cffi0 import backend_tests, test_function, test_ownlib
 from testing.support import u
 from cffi import FFI
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 
 class TestFFI(backend_tests.BackendTests,

--- a/testing/cffi0/test_version.py
+++ b/testing/cffi0/test_version.py
@@ -1,6 +1,6 @@
 import os, sys
 import pytest
-import cffi, _cffi_backend
+import cffi, _cffi_ft_backend as _cffi_backend
 from pathlib import Path
 
 def setup_module(mod):

--- a/testing/cffi0/test_zintegration.py
+++ b/testing/cffi0/test_zintegration.py
@@ -49,9 +49,9 @@ def create_venv(name):
     if site_packages:
         try:
             from cffi import _pycparser
-            modules = ('cffi', '_cffi_backend')
+            modules = ('cffi', '_cffi_ft_backend')
         except ImportError:
-            modules = ('cffi', '_cffi_backend', 'pycparser')
+            modules = ('cffi', '_cffi_ft_backend', 'pycparser')
             try:
                 import ply
             except ImportError:

--- a/testing/cffi1/test_cffi_binary.py
+++ b/testing/cffi1/test_cffi_binary.py
@@ -1,6 +1,6 @@
 import sys, os
 import pytest
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 from testing.support import is_musl
 
 def test_no_unknown_exported_symbols():
@@ -22,6 +22,6 @@ def test_no_unknown_exported_symbols():
         # a statically-linked libffi will always appear here without header hackage, ignore it if it's internal
         if name.startswith('ffi_') and 'Base' in line:
             continue
-        if name not in ('init_cffi_backend', 'PyInit__cffi_backend', 'cffistatic_ffi_call'):
+        if name not in ('init_cffi_ft_backend', 'PyInit__cffi_ft_backend', 'cffistatic_ffi_call'):
             raise Exception("Unexpected exported name %r" % (name,))
     g.close()

--- a/testing/cffi1/test_commontypes.py
+++ b/testing/cffi1/test_commontypes.py
@@ -1,6 +1,6 @@
 import os, cffi, re
 import pytest
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 
 def getlines():

--- a/testing/cffi1/test_dlopen.py
+++ b/testing/cffi1/test_dlopen.py
@@ -13,7 +13,7 @@ def test_simple():
     target = udir.join('test_simple.py')
     make_py_source(ffi, 'test_simple', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_simple',
     _version = 0x2601,
@@ -28,7 +28,7 @@ def test_global_constant():
     target = udir.join('test_valid_global_constant.py')
     make_py_source(ffi, 'test_valid_global_constant', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_valid_global_constant',
     _version = 0x2601,
@@ -58,7 +58,7 @@ def test_typename():
     target = udir.join('test_typename.py')
     make_py_source(ffi, 'test_typename', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_typename',
     _version = 0x2601,
@@ -73,7 +73,7 @@ def test_enum():
     target = udir.join('test_enum.py')
     make_py_source(ffi, 'test_enum', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_enum',
     _version = 0x2601,
@@ -89,7 +89,7 @@ def test_struct():
     target = udir.join('test_struct.py')
     make_py_source(ffi, 'test_struct', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_struct',
     _version = 0x2601,
@@ -105,7 +105,7 @@ def test_include():
     target = udir.join('test_include.py')
     make_py_source(ffi, 'test_include', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_include',
     _version = 0x2601,
@@ -119,7 +119,7 @@ ffi = _cffi_backend.FFI('test_include',
     target2 = udir.join('test2_include.py')
     make_py_source(ffi2, 'test2_include', str(target2))
     assert target2.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 from test_include import ffi as _ffi0
 
 ffi = _cffi_backend.FFI('test2_include',
@@ -135,7 +135,7 @@ def test_negative_constant():
     target = udir.join('test_negative_constant.py')
     make_py_source(ffi, 'test_negative_constant', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_negative_constant',
     _version = 0x2601,
@@ -154,7 +154,7 @@ def test_struct_included():
     target = udir.join('test_struct_included.py')
     make_py_source(ffi, 'test_struct_included', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 from test_struct_included_base import ffi as _ffi0
 
 ffi = _cffi_backend.FFI('test_struct_included',
@@ -181,7 +181,7 @@ def test_array():
     target = udir.join('test_array.py')
     make_py_source(ffi, 'test_array', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_array',
     _version = 0x2601,
@@ -203,7 +203,7 @@ def test_global_var():
     target = udir.join('test_global_var.py')
     make_py_source(ffi, 'test_global_var', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_global_var',
     _version = 0x2601,
@@ -218,7 +218,7 @@ def test_bitfield():
     target = udir.join('test_bitfield.py')
     make_py_source(ffi, 'test_bitfield', str(target))
     assert target.read() == r"""# auto-generated file
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 ffi = _cffi_backend.FFI('test_bitfield',
     _version = 0x2601,

--- a/testing/cffi1/test_ffi_obj.py
+++ b/testing/cffi1/test_ffi_obj.py
@@ -1,6 +1,6 @@
 import sys
 import pytest
-import _cffi_backend as _cffi1_backend
+import _cffi_ft_backend as _cffi1_backend
 
 
 def test_ffi_new():

--- a/testing/cffi1/test_re_python.py
+++ b/testing/cffi1/test_re_python.py
@@ -96,21 +96,21 @@ def test_large_constant():
     assert ffi.integer_const('BIGNEG') == -420000000000
 
 def test_function():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     from re_python_pysrc import ffi
     lib = ffi.dlopen(extmod)
     assert lib.add42(-10) == 32
     assert type(lib.add42) is _cffi_backend.FFI.CData
 
 def test_function_with_varargs():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     from re_python_pysrc import ffi
     lib = ffi.dlopen(extmod, 0)
     assert lib.add43(45, ffi.cast("int", -5)) == 45
     assert type(lib.add43) is _cffi_backend.FFI.CData
 
 def test_dlopen_none():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     from re_python_pysrc import ffi
     name = None
     if sys.platform == 'win32':
@@ -122,7 +122,7 @@ def test_dlopen_none():
     assert lib.strlen(b"hello") == 5
 
 def test_dlclose():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     from re_python_pysrc import ffi
     lib = ffi.dlopen(extmod)
     ffi.dlclose(lib)
@@ -226,7 +226,7 @@ def test_no_such_function_or_global_var():
         "symbol 'no_such_globalvar' not found in library '")
 
 def test_check_version():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     e = pytest.raises(ImportError, _cffi_backend.FFI,
                        "foobar", _version=0x2594)
     assert str(e.value).startswith(
@@ -271,7 +271,7 @@ def test_selfref():
     ffi.new("selfref_ptr_t")
 
 def test_dlopen_handle():
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     from re_python_pysrc import ffi
     if sys.platform == 'win32' or is_musl or sys.platform.startswith('freebsd'):
         pytest.skip("uses 'dl' explicitly")

--- a/testing/cffi1/test_realize_c_type.py
+++ b/testing/cffi1/test_realize_c_type.py
@@ -4,7 +4,7 @@ from cffi import cffi_opcode
 
 
 def check(input, expected_output=None, expected_ffi_error=False):
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     ffi = _cffi_backend.FFI()
     if not expected_ffi_error:
         ct = ffi.typeof(input)
@@ -49,7 +49,7 @@ def test_all_primitives():
         check(name, name)
 
 def check_func(input, expected_output=None):
-    import _cffi_backend
+    import _cffi_ft_backend as _cffi_backend
     ffi = _cffi_backend.FFI()
     ct = ffi.typeof(ffi.callback(input, lambda: None))
     assert isinstance(ct, ffi.CType)

--- a/testing/cffi1/test_unicode_literals.py
+++ b/testing/cffi1/test_unicode_literals.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 #
 #
 #
-from _cffi_backend import FFI
+from _cffi_ft_backend import FFI
 
 
 def test_cast():

--- a/testing/cffi1/test_verify1.py
+++ b/testing/cffi1/test_verify1.py
@@ -5,7 +5,7 @@ from cffi import CDefError
 from cffi import recompiler
 from testing.support import *
 from testing.support import _verify, extra_compile_args, is_musl
-import _cffi_backend
+import _cffi_ft_backend as _cffi_backend
 
 pytestmark = [
     pytest.mark.thread_unsafe,


### PR DESCRIPTION
In preparation for changing the name of the public `cffi` module, this changes the name of the private `_cffi_backend` module to `_cffi_ft_backend`. The ultimate goal here is to allow upstream CFFI and the fork to both be installed simultaneously without stepping on each other's module names.